### PR TITLE
[FIX] #45: Add Variable related to eamil to specify server type

### DIFF
--- a/dags/module/email_tasks.py
+++ b/dags/module/email_tasks.py
@@ -1,12 +1,14 @@
 from airflow.operators.email import EmailOperator
+from airflow.models import Variable
 
 
 def get_success_email_operator(to_email: str) -> EmailOperator:
+    environment = Variable.get("environment")
     return EmailOperator(
         task_id="send_success_email",
         to=to_email,
         subject="DAG Success: {{ task_instance.dag_id }}",
-        html_content="DAG: {{ task_instance.dag_id }}<br>Task: {{ task_instance.task_id }}<br>Execution Time: {{ ts }}<br>Log URL: {{ task_instance.log_url }}",
+        html_content="DAG: {{ task_instance.dag_id }}<br>Task: {{ task_instance.task_id }}<br>Execution Time: {{ ts }}<br>Environment: {environment}",
         conn_id="smtp_default",
         trigger_rule="all_success",
     )
@@ -17,7 +19,7 @@ def get_failure_email_operator(to_email: str) -> EmailOperator:
         task_id="send_failure_email",
         to=to_email,
         subject="DAG Failure: {{ task_instance.dag_id }}",
-        html_content="DAG: {{ task_instance.dag_id }}<br>Task: {{ task_instance.task_id }}<br>Execution Time: {{ ts }}<br>Log URL: {{ task_instance.log_url }}",
+        html_content="DAG: {{ task_instance.dag_id }}<br>Task: {{ task_instance.task_id }}<br>Execution Time: {{ ts }}<br>Environment: {environment}",
         conn_id="smtp_default",
         trigger_rule="one_failed",
     )


### PR DESCRIPTION
## Overview
    - 이메일을 받을 때 개발 서버에서 온 이메일인지 배포 서버에서 온 이메일인지 명시할 수 있도록 함
    
## Change Log
    - Variable에 관련 변수 추가
        - key: environment
        - value: "Development" 또는 "Production" 
    
## To Reviewer
    - airflow Variable에 environment 변수를 추가해야 이메일이 성공적으로 보내집니다. environment 변수를 추가하지 않으면 import 에러가 뜰 수 있습니다.
    
## Issue Tag
- Fixed: #45 
- See also: [TWD](https://www.notion.so/dohk325/57d344c2a0a84cc8b3090908ae5396ab?pvs=4)
