### PR TITLE
[FIX] #47: Refactor artifact path management to be dynamic in DAG

### DIFF
--- a/dags/module/upbit_price_prediction/btc/classification.py
+++ b/dags/module/upbit_price_prediction/btc/classification.py
@@ -11,6 +11,8 @@ import mlflow
 from mlflow.tracking import MlflowClient
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from info.connections import Connections
+from datetime import datetime
+
 
 # 로깅 설정
 logging.basicConfig(level=logging.INFO)
@@ -23,7 +25,11 @@ def train_catboost_model_fn(
     ),
     **context: dict,
 ) -> None:
-    mlflow.set_experiment("btc_catboost_model")
+    study_and_experiment_name = "btc_catboost_model_test"
+    mlflow.set_experiment(study_and_experiment_name)
+    experiment = mlflow.get_experiment_by_name(study_and_experiment_name)
+    experiment_id = experiment.experiment_id
+    run_name = f"run_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 
     # 데이터 로드
     engine = create_engine(hook.get_uri())
@@ -71,9 +77,8 @@ def train_catboost_model_fn(
         postgres_conn_id=Connections.HYPERPARAMETER_STORE.value
     )
     storage: RDBStorage = RDBStorage(url=postgresHook.get_uri())
-    study_name = "btc_catboost_model"
     study: optuna.study.Study = optuna.create_study(
-        study_name=study_name,
+        study_name=study_and_experiment_name,
         direction="maximize",
         storage=storage,
         load_if_exists=True,
@@ -104,15 +109,18 @@ def train_catboost_model_fn(
         "f1_score": f1,
     }
 
-    with mlflow.start_run() as run:
+    with mlflow.start_run(experiment_id=experiment_id, run_name=run_name) as run:
         mlflow.log_params(best_params)
         mlflow.log_metrics(metrics)
         model_info = mlflow.catboost.log_model(model, "model")
+        logger.info(f" model_info: {model_info}")
 
         # 모델을 등록하는 부분
         try:
             model_uri = f"runs:/{run.info.run_id}/model"
-            registered_model = mlflow.register_model(model_uri, "btc_catboost_model")
+            registered_model = mlflow.register_model(
+                model_uri, study_and_experiment_name
+            )
             logger.info(
                 f"Model registered: {registered_model.name}, version: {registered_model.version}"
             )


### PR DESCRIPTION
## Change Log
    - 실험의 번호를 mlflow-compose.yaml에 기입해야 했던 기존의 방식 대신, DAG 내에서 mlflow experiment 번호가 automatically 부여되도록 변경함
    
## Issue Tag
- Fixed: #47
- See also: [TWD](https://www.notion.so/dohk325/artifact-store-mlflow-compose-yaml-83190173b97a4122a716eeda5e88f53c?pvs=4)
