### PR TITLE
[FIX] Change file path and file name of start.sh, Add Essential commands to the sh file

### DIFF
--- a/backend-start.sh
+++ b/backend-start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Conda 초기화
+eval "$(conda shell.bash hook)"
+
+# Conda 환경 활성화
+conda activate fastapi
+
+# 작업 디렉토리 변경
+cd fastapi
+
+# 환경 변수 설정
+export AWS_ACCESS_KEY_ID=None
+export AWS_SECRET_ACCESS_KEY=None
+export MLFLOW_S3_ENDPOINT_URL=http://host:9000
+export MLFLOW_TRACKING_URI=http://host:5000
+
+# FastAPI 서버 시작
+uvicorn app.main:app --reload

--- a/fastapi/start.sh
+++ b/fastapi/start.sh
@@ -1,6 +1,0 @@
-export AWS_ACCESS_KEY_ID=None
-export AWS_SECRET_ACCESS_KEY=None
-export MLFLOW_S3_ENDPOINT_URL=http://localhost:9000
-export MLFLOW_TRACKING_URI=http://host:5000
-
-uvicorn app.main:app --reload


### PR DESCRIPTION
## Overview
    - start.sh 파일로 FastAPI 백엔드 서비스를 시작한다. 이 서비스를 시작하기 위해서는 최상위 디렉토리 내의 fastapi 폴더 내로 들어가서 실행해야 하는데 생각보다 번거롭다.
    - 또한, FastAPI를 실행시키기 위해 매번 conda activate해야하는 것도 번거롭다.

    
## Change Log
    - start.sh의 위치를 디렉토리 최상단(FastAPI subproject의 바깥)으로 이동
    - start.sh의 파일 이름을 직관적으로 변경: backend-start.sh
    - FastAPI 외부로 옮겨진 start.sh로 FastAPI 백엔드 서비스를 실행시킬 수 있도록 하기 위해 shell 스크립트 수정
    
## Issue Tag
- Fixed: #56 