### PR TITLE
[FEAT] 전처리 함수 수정 및 기능 추가

### DIFF
--- a/dags/module/upbit_price_prediction/btc/create_table.py
+++ b/dags/module/upbit_price_prediction/btc/create_table.py
@@ -33,15 +33,14 @@ def create_table_fn(
 
     engine = create_engine(hook.get_uri())
     inspector = inspect(engine)
-
+    ti = context["ti"]
     if inspector.has_table("btc_ohlcv"):
         logger.info("Table 'btc_ohlcv' already exists.")
-
-        context["ti"].xcom_push(key="table_created", value=False)
-        context["ti"].xcom_push(key="db_uri", value=hook.get_uri())
+        ti.xcom_push(key="table_created", value=False)
+        ti.xcom_push(key="db_uri", value=hook.get_uri())
         raise AirflowSkipException("Table 'btc_ohlcv' already exists.")
     else:
         Base.metadata.create_all(engine)
         logger.info("Checked and created tables if not existing.")
-        context["ti"].xcom_push(key="table_created", value=True)
-        context["ti"].xcom_push(key="db_uri", value=hook.get_uri())
+        ti.xcom_push(key="table_created", value=True)
+        ti.xcom_push(key="db_uri", value=hook.get_uri())

--- a/dags/module/upbit_price_prediction/btc/preprocess.py
+++ b/dags/module/upbit_price_prediction/btc/preprocess.py
@@ -9,10 +9,6 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import declarative_base, sessionmaker
 from info.connections import Connections
 from contextvars import ContextVar
-from info.connections import Connections
-from contextvars import ContextVar
-from info.connections import Connections
-from contextvars import ContextVar
 from datetime import datetime
 import logging
 import asyncio
@@ -55,7 +51,6 @@ session_context = ContextVar("session_context", default=None)
 
 async def fill_missing_and_null_data(session, conn, past_new_time_str, new_time_str):
     # 이번 파이프라인에서 적재된 데이터 중 누락된 데이터 or null 값이 있는 데이터를 확인해서 선형보간법으로 채워줌
-
     new_time = datetime.fromisoformat(new_time_str)
 
     # 만약 존재하면 datetime으로 바꿔주고, 없을 시 0으로 할당

--- a/dags/module/upbit_price_prediction/btc/preprocess.py
+++ b/dags/module/upbit_price_prediction/btc/preprocess.py
@@ -9,8 +9,15 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import declarative_base, sessionmaker
 from info.connections import Connections
 from contextvars import ContextVar
+from info.connections import Connections
+from contextvars import ContextVar
 from datetime import datetime
 import logging
+import asyncio
+import uvloop
+
+# uvloop를 기본 이벤트 루프로 설정
+asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 import asyncio
 import uvloop
 
@@ -305,11 +312,15 @@ async def preprocess_data(context):
                     select(func.count()).select_from(BtcPreprocessed)
                 )
                 logger.info(f"Final Count of rows in btc_preprocessed: {count_final}")
+                logger.info(f"Final Count of rows in btc_preprocessed: {count_final}")
 
+            await conn.commit()
             await conn.commit()
 
         logger.info("Label column added and updated successfully.")
+        logger.info("Label column added and updated successfully.")
     except Exception as e:
+        await conn.rollback()
         await conn.rollback()
         logger.error(f"Data preprocessing failed: {e}")
         raise

--- a/dags/module/upbit_price_prediction/btc/save_raw_data.py
+++ b/dags/module/upbit_price_prediction/btc/save_raw_data.py
@@ -138,6 +138,7 @@ async def insert_data_into_db(data: list, session, initial_insert: bool) -> None
 
                 result = await session.execute(stmt)
                 inserted_count += len(result.fetchall())
+
         else:
             for record in data:
                 stmt = (

--- a/dags/module/upbit_price_prediction/btc/save_raw_data.py
+++ b/dags/module/upbit_price_prediction/btc/save_raw_data.py
@@ -25,7 +25,6 @@ import uvloop
 import jwt
 import uuid
 
-
 # uvloop를 기본 이벤트 루프로 설정
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
@@ -136,8 +135,6 @@ async def insert_data_into_db(data: list, session) -> None:
 
 
 # 현재 시간(UTC+9)으로부터 365일이 지난 데이터를 데이터베이스에서 삭제하는 함수
-
-
 async def delete_old_data(session):
     try:
         threshold_date = datetime.now() - timedelta(days=365)

--- a/dags/module/upbit_price_prediction/btc/save_raw_data.py
+++ b/dags/module/upbit_price_prediction/btc/save_raw_data.py
@@ -15,6 +15,8 @@ import logging
 import os
 from info.api import APIInformation
 from dags.module.upbit_price_prediction.btc.create_table import BtcOhlcv, Base
+from pytz import timezone
+
 
 # 로깅 설정
 logging.basicConfig(level=logging.INFO)
@@ -88,11 +90,7 @@ async def fetch_ohlcv_data(session, market: str, to: str, count: int, retry=3):
 
 
 # 데이터베이스에 데이터를 삽입하는 함수
-async def insert_data_into_db(data: list, db_uri: str) -> None:
-    engine = create_engine(db_uri)
-    Session = sessionmaker(bind=engine)
-    session = Session()
-
+async def insert_data_into_db(data: list, session) -> None:
     try:
         for record in data:
             logger.debug(f"Inserting record: {record}")  # 디버그용 로그 추가
@@ -129,13 +127,20 @@ async def insert_data_into_db(data: list, db_uri: str) -> None:
 
 
 # 현재 시간(UTC+9)으로부터 365일이 지난 데이터를 데이터베이스에서 삭제하는 함수
-async def delete_old_data(db_uri: str):
-    engine = create_engine(db_uri)
-    Session = sessionmaker(bind=engine)
-    session = Session()
-
+async def delete_old_data(session):
     try:
-        threshold_date = datetime.utcnow() + timedelta(hours=9) - timedelta(days=365)
+        # KST 시간대 설정
+        kst = timezone("Asia/Seoul")
+        now_kst = datetime.now(tz=kst)
+        threshold_date = now_kst - timedelta(days=365)
+        logger.info(f"Threshold date for deletion: {threshold_date}")
+
+        # 디버그를 위해 삭제할 데이터의 개수를 먼저 확인
+        count_query = (
+            session.query(BtcOhlcv).filter(BtcOhlcv.time < threshold_date).count()
+        )
+        logger.info(f"Number of records to be deleted: {count_query}")
+
         deleted_rows = (
             session.query(BtcOhlcv).filter(BtcOhlcv.time < threshold_date).delete()
         )
@@ -149,11 +154,7 @@ async def delete_old_data(db_uri: str):
 
 
 # 데이터베이스에 기록된 가장 최근의 시간 데이터를 가져오는 함수
-def get_most_recent_data_time(db_uri: str) -> datetime:
-    engine = create_engine(db_uri)
-    Session = sessionmaker(bind=engine)
-    session = Session()
-
+def get_most_recent_data_time(session) -> datetime:
     most_recent_time = (
         session.query(BtcOhlcv.time).order_by(BtcOhlcv.time.desc()).first()
     )
@@ -167,22 +168,38 @@ def get_most_recent_data_time(db_uri: str) -> datetime:
 
 # 데이터를 수집하고 데이터베이스에 적재하며, 365일이 지난 데이터를 삭제하는 함수
 async def collect_and_load_data(db_uri: str, context: dict) -> None:
-    async with aiohttp.ClientSession() as session:
-        most_recent_time = get_most_recent_data_time(db_uri)
+    """
+    most_recent_time : db에 찍혀있는 데이터 중 가장 최근 시간 (없으면 None)
+    current_time : 현재 시간(kst기준)
+    most_recen_time을 적절하게 설정하여 최초 삽입시 1년치 데이터를 삽입, 그 이후부터는 db의 가장최근시간 ~ 현재시간까지의 데이터를 삽입
+    삽입 전에 공통적으로 현재시간 대비 1년이 지난 과거 데이터는 삭제하는 작업을 거친 후 데이터가 삽입됨
+    """
+    async with aiohttp.ClientSession() as aiohttp_session:
+        engine = create_engine(db_uri)
+        Session = sessionmaker(bind=engine)
+        session = Session()
+
+        most_recent_time = get_most_recent_data_time(session)
         current_time = datetime.now() + timedelta(hours=9)
 
+        # db에 데이터가 들어온적이 있다면 그대로 진행
         if most_recent_time:
             logger.info(
                 f"most_recent_time: {most_recent_time}, current_time: {current_time}"
             )
+            initial_insert = False
+        # db에 데이터가 들어온 적이 없다면 most_recent_time을 1년전의 시간으로 설정해서 1년치 데이터를 가져올 수 있도록 셋팅
         else:
             logger.info(
                 f"No recent data found, setting most_recent_time to one year ago from current_time"
             )
             most_recent_time = current_time - timedelta(days=365)
-
+            initial_insert = True
         time_diff = current_time - most_recent_time
         logger.info(f"time_diff: {time_diff}")
+
+        # 최초 삽입 여부를 XCom에 푸시
+        context["ti"].xcom_push(key="initial_insert", value=initial_insert)
 
         if time_diff < timedelta(hours=1):
             logger.info("Data is already up to date.")
@@ -194,7 +211,7 @@ async def collect_and_load_data(db_uri: str, context: dict) -> None:
         while time_diff > timedelta(0):
             logger.info(f"Fetching data up to {to_time}")
             new_data = await fetch_ohlcv_data(
-                session, "KRW-BTC", to_time.strftime("%Y-%m-%dT%H:%M:%S"), 200
+                aiohttp_session, "KRW-BTC", to_time.strftime("%Y-%m-%dT%H:%M:%S"), 200
             )
             if not new_data:
                 break
@@ -206,10 +223,16 @@ async def collect_and_load_data(db_uri: str, context: dict) -> None:
             time_diff = to_time - most_recent_time
             logger.info(f"Collected {len(new_data)} records, time_diff: {time_diff}")
 
-        logger.info(f"Total collected records: {len(data)}")
+        logger.info(f"initial collected records: {len(data)}")
 
-        await insert_data_into_db(data, db_uri)
-        # await delete_old_data(db_uri)
+        await insert_data_into_db(data, session)
+
+        # 데이터 삽입 후 365일이 지난 데이터를 삭제
+        await delete_old_data(session)
+
+        count_final = session.query(BtcOhlcv).count()
+        logger.info(f"Total collected records: {count_final}")
+        session.close()
 
         # 새로운 데이터의 시간을 XCom에 푸시
         if data:

--- a/dags/module/upbit_price_prediction/btc/save_raw_data.py
+++ b/dags/module/upbit_price_prediction/btc/save_raw_data.py
@@ -8,11 +8,23 @@ from typing import Optional, Tuple, Dict
 from info.api import APIInformation
 
 import logging
+from dags.module.upbit_price_prediction.btc.create_table import BtcOhlcv
+
+from datetime import datetime, timedelta
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from typing import Optional, Tuple, Dict
+from info.api import APIInformation
+
+import logging
 import asyncio
 import aiohttp
 import uvloop
+import uvloop
 import jwt
 import uuid
+
 
 # uvloop를 기본 이벤트 루프로 설정
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
@@ -124,6 +136,8 @@ async def insert_data_into_db(data: list, session) -> None:
 
 
 # 현재 시간(UTC+9)으로부터 365일이 지난 데이터를 데이터베이스에서 삭제하는 함수
+
+
 async def delete_old_data(session):
     try:
         threshold_date = datetime.now() - timedelta(days=365)
@@ -185,6 +199,7 @@ async def collect_and_load_data(db_uri: str, context: dict) -> None:
             logger.info(
                 f"most_recent_time: {most_recent_time}, current_time: {current_time}"
             )
+
             initial_insert = False
         # db에 데이터가 들어온 적이 없다면 most_recent_time을 1년전의 시간으로 설정해서 1년치 데이터를 가져올 수 있도록 셋팅
         else:

--- a/dags/module/upbit_price_prediction/btc/save_raw_data.py
+++ b/dags/module/upbit_price_prediction/btc/save_raw_data.py
@@ -1,11 +1,17 @@
 from dags.module.upbit_price_prediction.btc.create_table import BtcOhlcv
 
 from datetime import datetime, timedelta
-from sqlalchemy import create_engine
+from sqlalchemy import select, func, text
+from sqlalchemy.ext.asyncio import (
+    create_async_engine,
+    AsyncSession,
+    async_scoped_session,
+)
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from typing import Optional, Tuple, Dict
 from info.api import APIInformation
+from contextvars import ContextVar
 
 import logging
 import asyncio
@@ -15,6 +21,7 @@ import uvloop
 import jwt
 import uuid
 import time
+import psutil
 
 # uvloop를 기본 이벤트 루프로 설정
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
@@ -22,6 +29,9 @@ asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 # 로깅 설정
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+# ContextVar를 사용하여 세션을 관리(비동기 함수간에 컨텍스트를 안전하게 전달하도록 해줌. 세션을 여러 코루틴간에 공유 가능)
+session_context = ContextVar("session_context", default=None)
 
 
 # JWT 생성 함수
@@ -91,177 +101,279 @@ async def fetch_ohlcv_data(session, market: str, to: str, count: int, retry=3):
 
 
 # 데이터베이스에 데이터를 삽입하는 함수
-async def insert_data_into_db(data: list, session) -> None:
+async def insert_data_into_db(data: list, session, initial_insert: bool) -> None:
     try:
+        # 청크 최적화를 위해 cpu, 메모리사용량, 속도 테스트
+        start_time = time.time()
+        process = psutil.Process()
+        initial_memory = process.memory_info().rss
+        initial_cpu = process.cpu_percent(interval=None)
+
+        # # 최대 인수 개수 (postgresql의 최대 개수 = 32767)
+        # max_args = 32767
+        # # 각 행에 필요한 인수 개수
+        # args = 6
+        # # 청크 크기 계산
+        # chunk_size = max_args // args
+        chunk_size = 100
+
         inserted_count = 0
-        for record in data:
-            logger.debug(f"Inserting record: {record}")  # 디버그용 로그 추가
-            stmt = (
-                pg_insert(BtcOhlcv)
-                .values(
-                    time=datetime.fromisoformat(record["candle_date_time_kst"]),
-                    open=record["opening_price"],
-                    high=record["high_price"],
-                    low=record["low_price"],
-                    close=record["trade_price"],
-                    volume=record["candle_acc_trade_volume"],
-                )
-                .on_conflict_do_update(
-                    index_elements=["time"],
-                    set_={
+        if initial_insert:
+            #     # 최초 삽입 시 데이터 청크 단위로 나누어 삽입
+            #     # 한 번에 너무 많은 데이터를 넣지 않도록 해서 메모리 사용량을 줄이고 db와의 통신시간 줄일 수 있다
+            # for i in range(0, len(data), chunk_size):
+            #     chunk = data[i:i + chunk_size]
+            #     bulk_data = [
+            #         {
+            #             "time": datetime.fromisoformat(record["candle_date_time_kst"]),
+            #             "open": record["opening_price"],
+            #             "high": record["high_price"],
+            #             "low": record["low_price"],
+            #             "close": record["trade_price"],
+            #             "volume": record["candle_acc_trade_volume"],
+            #         }
+            #         for record in chunk
+            #     ]
+
+            #     stmt = pg_insert(BtcOhlcv).values(bulk_data).on_conflict_do_nothing().returning(BtcOhlcv.time)
+
+            #     result = await session.execute(stmt)
+            #     inserted_count += len(result.fetchall())
+
+            async def process_chunk(chunk):
+                bulk_data = [
+                    {
+                        "time": datetime.fromisoformat(record["candle_date_time_kst"]),
                         "open": record["opening_price"],
                         "high": record["high_price"],
                         "low": record["low_price"],
                         "close": record["trade_price"],
                         "volume": record["candle_acc_trade_volume"],
-                    },
-                )
-                .returning(BtcOhlcv.time)  # Insert된 행의 수를 반환하기위해사용
-            )
-            result = session.execute(stmt)
-            inserted_count += len(result.fetchall())
+                    }
+                    for record in chunk
+                ]
 
-        session.commit()
+                stmt = (
+                    pg_insert(BtcOhlcv)
+                    .values(bulk_data)
+                    .on_conflict_do_nothing()
+                    .returning(BtcOhlcv.time)
+                )
+                result = await session.execute(stmt)
+                return len(result.fetchall())
+
+            tasks = [
+                process_chunk(data[i : i + chunk_size])
+                for i in range(0, len(data), chunk_size)
+            ]
+            results = await asyncio.gather(*tasks)
+            inserted_count = sum(results)
+        else:
+            for record in data:
+                stmt = (
+                    pg_insert(BtcOhlcv)
+                    .values(
+                        time=datetime.fromisoformat(record["candle_date_time_kst"]),
+                        open=record["opening_price"],
+                        high=record["high_price"],
+                        low=record["low_price"],
+                        close=record["trade_price"],
+                        volume=record["candle_acc_trade_volume"],
+                    )
+                    .on_conflict_do_update(
+                        index_elements=["time"],
+                        set_={
+                            "open": record["opening_price"],
+                            "high": record["high_price"],
+                            "low": record["low_price"],
+                            "close": record["trade_price"],
+                            "volume": record["candle_acc_trade_volume"],
+                        },
+                    )
+                    .returning(BtcOhlcv.time)  # Insert된 행의 수를 반환하기위해사용
+                )
+                result = await session.execute(stmt)
+                inserted_count += len(result.fetchall())
+
+        await session.commit()
+
+        end_time = time.time()
+        elapsed_time = end_time - start_time
+        final_memory = process.memory_info().rss
+        final_cpu = process.cpu_percent(interval=None)
+        memory_usage = final_memory - initial_memory
+        cpu_usage = final_cpu - initial_cpu
+        logger.info(
+            f"Chunk size: {chunk_size}, Inserted records: {inserted_count}, Time taken: {elapsed_time:.4f} seconds"
+        )
+        logger.info(
+            f"Memory usage: {memory_usage / (1024 * 1024):.2f} MB, CPU usage: {cpu_usage:.2f}%"
+        )
+
         logger.info("Data inserted successfully")
         logger.info(f"Inserted Data counts: {inserted_count}")
 
     except Exception as e:
-        session.rollback()
+        await session.rollback()
         logger.error(f"Failed to insert data into database: {e}")
         raise e
 
 
 # 현재 시간(UTC+9)으로부터 365일이 지난 데이터를 데이터베이스에서 삭제하는 함수
-async def delete_old_data(session):
+async def delete_old_data(session: AsyncSession) -> None:
     try:
         threshold_date = datetime.now() - timedelta(days=365)
         threshold_kst = threshold_date + timedelta(hours=9)
         logger.info(f"Threshold date for deletion: {threshold_kst}")
 
         # 디버그를 위해 삭제할 데이터의 개수를 먼저 확인
-        count_query = (
-            session.query(BtcOhlcv)
-            .filter(BtcOhlcv.time < threshold_date + timedelta(hours=9))
-            .count()
-        )
-        logger.info(f"Number of records to be deleted: {count_query}")
+        count_query = select(func.count()).where(BtcOhlcv.time < threshold_kst)
+        result = await session.execute(count_query)
+        delete_count = result.scalar()
+        logger.info(f"Number of records to be deleted: {delete_count}")
 
-        deleted_rows = (
-            session.query(BtcOhlcv)
-            .filter(BtcOhlcv.time < threshold_date + timedelta(hours=9))
-            .delete()
-        )
-        session.commit()
-        logger.info(f"Deleted {deleted_rows} old records from the database.")
+        delete_query = BtcOhlcv.__table__.delete().where(BtcOhlcv.time < threshold_kst)
+        await session.execute(delete_query)
+        await session.commit()
+        logger.info(f"Deleted {delete_count} old records from the database.")
     except Exception as e:
         session.rollback()
         logger.error(f"Failed to delete old data: {e}")
+        raise
 
 
 # 데이터베이스에 기록된 가장 최근의 시간 데이터를 가져오는 함수
-def get_most_recent_data_time(session) -> datetime:
-    most_recent_time = (
-        session.query(BtcOhlcv.time).order_by(BtcOhlcv.time.desc()).first()
-    )
-
-    if most_recent_time:
-        logger.info("most_recent_time: {}".format(most_recent_time[0]))
-        return most_recent_time[0]
-    else:
-        return None
+async def get_most_recent_data_time(session: AsyncSession) -> Optional[datetime]:
+    try:
+        result = await session.execute(
+            select(BtcOhlcv.time).order_by(BtcOhlcv.time.desc()).limit(1)
+        )
+        most_recent_time = result.scalar()
+        if most_recent_time:
+            logger.info("most_recent_time: {most_recent_time}")
+        return most_recent_time
+    except Exception as e:
+        logger.error(f"Failed to fetch most recent data time: {e}")
+        raise
 
 
 # 데이터를 수집하고 데이터베이스에 적재하며, 365일이 지난 데이터를 삭제하는 함수
 async def collect_and_load_data(db_uri: str, context: dict) -> None:
     """
+    - 세션 관련 변수에 대한 설명
+    session_context : 여러 코루틴간에 세션을 안전하게 전달할 수 있도록 도와주는 ContextVar를 사용
+    session_factory : sessionmaker로 AsyncSession클래스를 상요하여 세션을 생성
+    AsyncScopedSession : 스코프 단위로 관리해서 디오기함수간에 세션을 공유할 수 있도록 함(세션의 범위를 session_context을 사용하여 관리)
+    token : 컨텍스트 변수의 현재 상태를 저장. 이를 통해 세션상태를 안전하게 관리할 수 있음
+
+    - 시간 관련 변수에 대한 설명
     most_recent_time : 삽입 전 db에 찍혀있는 데이터 중 가장 최근 시간 (없으면 None)
     current_time : 현재 시간(kst기준)
     most_recen_time을 적절하게 설정하여 최초 삽입시 1년치 데이터를 삽입, 그 이후부터는 db의 가장최근시간 ~ 현재시간까지의 데이터를 삽입
     삽입 전에 공통적으로 현재시간 대비 1년이 지난 과거 데이터는 삭제하는 작업을 거친 후 데이터가 삽입됨
-    initial_insert를 True or False로 설정하여 다음 task에서 이 상태에 맞게 효율적으로 작업할 수 있도록 xcom_push로 전달해줌
+    데이터 최초삽입 여부를 initial_insert변수에 True or False로 설정하여 다음 task에서 이 상태에 맞게 효율적으로 작업할 수 있도록 xcom_push로 전달해줌
     """
-
     async with aiohttp.ClientSession() as aiohttp_session:
-        engine = create_engine(db_uri)
-        Session = sessionmaker(bind=engine)
-        session = Session()
+        engine = create_async_engine(
+            db_uri.replace("postgresql", "postgresql+asyncpg"), future=True
+        )
+        session_factory = sessionmaker(
+            engine, expire_on_commit=False, class_=AsyncSession
+        )
+        AsyncScopedSession = async_scoped_session(
+            session_factory, scopefunc=session_context.get
+        )
 
-        most_recent_time = get_most_recent_data_time(session)
-        current_time = datetime.now() + timedelta(hours=9)
+        token = session_context.set(session_factory)
 
-        # db에 데이터가 들어온적이 있다면 그대로 진행
-        if most_recent_time:
-            logger.info(
-                f"most_recent_time: {most_recent_time}, current_time: {current_time}"
+        async with AsyncScopedSession() as session:
+            most_recent_time = await get_most_recent_data_time(session)
+            current_time = datetime.now() + timedelta(hours=9)
+
+            # db에 데이터가 들어온적이 있다면 그대로 진행
+            if most_recent_time:
+                logger.info(
+                    f"most_recent_time: {most_recent_time}, current_time: {current_time}"
+                )
+
+                initial_insert = False
+            # db에 데이터가 들어온 적이 없다면 most_recent_time을 1년전의 시간으로 설정해서 1년치 데이터를 가져올 수 있도록 셋팅
+            else:
+                logger.info(
+                    f"No recent data found, setting most_recent_time to one year ago from current_time"
+                )
+                most_recent_time = current_time - timedelta(days=365)
+                initial_insert = True
+
+            time_diff = current_time - most_recent_time
+            logger.info(f"time_diff: {time_diff}")
+
+            # 최초 삽입 여부와 현재시간을 XCom에 푸시
+            ti = context["ti"]
+            ti.xcom_push(key="initial_insert", value=initial_insert)
+            ti.xcom_push(key="current_time", value=current_time.isoformat())
+            get_time_before = await get_most_recent_data_time(session)
+
+            # 최초삽입시에는 past_new_time이 의미가 없기 때문에 존재할 경우에만 적재전의 db의 최신데이터 시간을 Xcom에 푸시
+            if get_time_before:
+                ti.xcom_push(key="past_new_time", value=get_time_before.isoformat())
+
+            if time_diff < timedelta(hours=1):
+                logger.info("Data is already up to date.")
+                return
+
+            data = []
+
+            to_time = current_time
+
+            while time_diff > timedelta(0):
+                logger.info(f"Fetching data up to {to_time}")
+                new_data = await fetch_ohlcv_data(
+                    aiohttp_session,
+                    "KRW-BTC",
+                    to_time.strftime("%Y-%m-%dT%H:%M:%S"),
+                    200,
+                )
+                if not new_data:
+                    break
+                data.extend(new_data)
+                last_record_time = datetime.fromisoformat(
+                    new_data[-1]["candle_date_time_kst"]
+                )
+                to_time = last_record_time - timedelta(minutes=60)
+                time_diff = to_time - most_recent_time
+                logger.info(
+                    f"Collected {len(new_data)} records, time_diff: {time_diff}"
+                )
+
+            logger.info(f"initial collected records: {len(data)}")
+
+            await insert_data_into_db(data, session, initial_insert)
+
+            count_total_result = await session.execute(
+                text("SELECT COUNT(*) FROM btc_ohlcv")
             )
+            count_total = count_total_result.scalar()
+            logger.info(f"Total collected records before delete: {count_total}")
+            # 데이터 삽입 후 365일이 지난 데이터를 삭제
+            await delete_old_data(session)
 
-            initial_insert = False
-        # db에 데이터가 들어온 적이 없다면 most_recent_time을 1년전의 시간으로 설정해서 1년치 데이터를 가져올 수 있도록 셋팅
-        else:
-            logger.info(
-                f"No recent data found, setting most_recent_time to one year ago from current_time"
+            count_final_result = await session.execute(
+                text("SELECT COUNT(*) FROM btc_ohlcv")
             )
-            most_recent_time = current_time - timedelta(days=365)
-            initial_insert = True
+            count_final = count_final_result.scalar()
+            logger.info(f"Final collected records: {count_final}")
 
-        time_diff = current_time - most_recent_time
-        logger.info(f"time_diff: {time_diff}")
+            # 데이터 적재 후 가장 최신 시간을 new_time으로 푸시
+            latest_time = await get_most_recent_data_time(session)
 
-        # 최초 삽입 여부와 현재시간을 XCom에 푸시
-        context["ti"].xcom_push(key="initial_insert", value=initial_insert)
-        context["ti"].xcom_push(key="current_time", value=current_time.isoformat())
-        get_time_before = get_most_recent_data_time(session)
+            # 만약 존재하면 최신 데이터시간, 아니면 현재시간으로 푸시
+            if latest_time:
+                ti.xcom_push(key="new_time", value=latest_time.isoformat())
+            else:
+                ti.xcom_push(key="new_time", value=current_time.isoformat())
 
-        # 최초삽입시에는 past_new_time이 의미가 없기 때문에 존재할 경우에만 적재전의 db의 최신데이터 시간을 Xcom에 푸시
-        if get_time_before:
-            context["ti"].xcom_push(
-                key="past_new_time", value=get_time_before.isoformat()
-            )
-
-        if time_diff < timedelta(hours=1):
-            logger.info("Data is already up to date.")
-            return
-
-        data = []
-
-        to_time = current_time
-
-        while time_diff > timedelta(0):
-            logger.info(f"Fetching data up to {to_time}")
-            new_data = await fetch_ohlcv_data(
-                aiohttp_session, "KRW-BTC", to_time.strftime("%Y-%m-%dT%H:%M:%S"), 200
-            )
-            if not new_data:
-                break
-            data.extend(new_data)
-            last_record_time = datetime.fromisoformat(
-                new_data[-1]["candle_date_time_kst"]
-            )
-            to_time = last_record_time - timedelta(minutes=60)
-            time_diff = to_time - most_recent_time
-            logger.info(f"Collected {len(new_data)} records, time_diff: {time_diff}")
-
-        logger.info(f"initial collected records: {len(data)}")
-
-        await insert_data_into_db(data, session)
-
-        count_total = session.query(BtcOhlcv).count()
-        logger.info(f"Total collected records before delete: {count_total}")
-        # 데이터 삽입 후 365일이 지난 데이터를 삭제
-        await delete_old_data(session)
-
-        count_final = session.query(BtcOhlcv).count()
-        logger.info(f"Final collected records: {count_final}")
-
-        # 데이터 적재 후 가장 최신 시간을 new_time으로 푸시
-        latest_time = get_most_recent_data_time(session)
-        session.close()
-
-        # 만약 존재하면 최신 데이터시간, 아니면 현재시간으로 푸시
-        if latest_time:
-            context["ti"].xcom_push(key="new_time", value=latest_time.isoformat())
-        else:
-            context["ti"].xcom_push(key="new_time", value=current_time.isoformat())
+        session_context.reset(token)
 
 
 # Airflow Task에서 호출될 함수

--- a/requirements.txt
+++ b/requirements.txt
@@ -171,3 +171,4 @@ xgboost==2.0.3
 matplotlib==3.9.0
 seaborn==0.13.2
 catboost==1.2.5
+asyncpg==0.29.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -172,3 +172,4 @@ matplotlib==3.9.0
 seaborn==0.13.2
 catboost==1.2.5
 asyncpg==0.29.0
+psutil==5.9.8


### PR DESCRIPTION
## Overview
    - 기존에 데이터 적재시 문제가 있었던 부분 수정 및 누락된데이터, null값 데이터 등에 대해 선형보간법으로 처리   
    
## Change Log
    - 기존에 데이터 호출해서 적재할 때 1년이 지난 데이터를 삭제하는 작업이 제대로 안되던 부분 해결
    - create_table 에서 hook으로 가져왔던 db_uri를 xcom에 저장 후 이후 태스크에서 필요시 pull해서 사용하도록 수정    
    - save_raw_data, preprocess 에서 데이터가 최초로 삽입되었는지 아닌지로 구분해서 최초삽입 시 대용량 데이터 삽입에 좀 더 효율적인 방식으로 수정 ( 이 부분에 대한 세부사항은 팀 노션 twd: btc_preprocessed 이슈 에 작성해두었음)    
    - save_raw_data.py 와의 코드 통일성을 위해, 그리고 효율적인 i/o바운드 작업을 위해 preprocess.py 도 비동기함수로 변경
    - preprocess 함수 분리
    - classification.py 에서 전체 데이터를 한번 불러오는 작업을 비동기함수로 따로 빼서 작동하도록 수정
        
## To Reviewer
    - 기본 DB_TYPE은 postgresql 으로 기존처럼 설정해놓고 필요시에만 postgresql+asyncpg 로 바꿔서 비동기엔진 사용
    - 어렵거나 생소하다고 느껴지는 구문들, 그리고 추가한 XCom 변수들에 대해 간단하게 주석으로 설명 적어놨습니다.
    - save_raw_data의 최초삽입시 데이터 적재하는 시간을 줄이는데 성공하였고 테스트한거는 노션 twd에 기록했습니다
    - btc_ohlcv, btc_preprocessed 테이블을 완전 삭제 후 테스트, 최근 n개의 행 삭제 후 테스트 완료 (이외의 복잡한 상황은 고려x)
    - 현재 이 PR 이후로는 데이터 맨 앞,뒤가 누락된 경우 선형보간법을 적용할 수 없는 문제 해결, 5분봉 데이터로 바꾸고 테스트해보기 등의 작업을 할 예정입니다.   
    
## Issue Tag
- Closed | Fixed: #52 
