### PR TITLE
[FEAT] 전처리 함수 추가 보강작업 (이동평균 사용)

### DIFF
--- a/dags/module/upbit_price_prediction/btc/classification.py
+++ b/dags/module/upbit_price_prediction/btc/classification.py
@@ -14,6 +14,7 @@ import optuna
 import pandas as pd
 import mlflow
 import uvloop
+import time
 
 # uvloop를 기본 이벤트 루프로 설정
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
@@ -36,7 +37,7 @@ async def load_data(engine) -> pd.DataFrame:
 
 
 def train_catboost_model_fn(**context: dict) -> None:
-
+    s = time.time()
     study_and_experiment_name = "btc_catboost_alpha"
     mlflow.set_experiment(study_and_experiment_name)
     experiment = mlflow.get_experiment_by_name(study_and_experiment_name)
@@ -149,9 +150,13 @@ def train_catboost_model_fn(**context: dict) -> None:
         logger.info(
             f"Model trained and logged, run_id: {run.info.run_id}, model_uri: {model_uri}, registered_model_version: {registered_model.version}"
         )
+        e = time.time()
+        es = e - s
+        logger.info(f"Total working time : {es:.4f} sec")
 
 
 def create_model_version(**context: dict) -> None:
+    s = time.time()
     ti = context["ti"]
     model_name: str = ti.xcom_pull(key="model_name")
     run_id = ti.xcom_pull(key="run_id")
@@ -172,9 +177,13 @@ def create_model_version(**context: dict) -> None:
 
     ti.xcom_push(key="model_version", value=model_version.version)
     logger.info(f"Model version created: {model_version.version}")
+    e = time.time()
+    es = e - s
+    logger.info(f"Total working time : {es:.4f} sec")
 
 
 def transition_model_stage(**context: dict) -> None:
+    s = time.time()
     ti = context["ti"]
     model_name: str = ti.xcom_pull(key="model_name")
     version = ti.xcom_pull(key="model_version")
@@ -212,3 +221,6 @@ def transition_model_stage(**context: dict) -> None:
 
     ti.xcom_push(key="production_version", value=production_model.version)
     logger.info(f"Production model deployed: version {production_model.version}")
+    e = time.time()
+    es = e - s
+    logger.info(f"Total working time : {es:.4f} sec")


### PR DESCRIPTION
## Overview
    - 기존 preprocess.py 에서 결측치 데이터에 대해 선형보간법으로 대체하던 부분을 이동평균으로 대체하도록 수정
    
## Change Log
    - preprocess.py 에서 누락된데이터 or null값이 들어있는 데이터에 대해 몇분봉 데이터인지에 따라서 적절한 이동평균 기간을 동적으로 설정(p.155~205)하여 이동평균으로 대체해서 채워넣음
    - 정렬이 제대로 안되던 문제 해결 (CLUSTER로 정렬했었는데 일회성 정렬이라는 단점 존재.) -> 그냥 orm으로 간단히 orderby time 으로 해결
    
## To Reviewer
    - 각 task별로 총 걸리는 시간을 체크할 수 있도록 맨마지막에 로그로 뜨도록 설정해놨습니다(Total working time: ~)
    - 이동평균으로 채워 넣을 때 (이동평균으로 사용된 데이터의 표준편차 * noise_factor) 로 랜덤하게 노이즈를 생성해서 조금 더 변동성을 유지하도록 했습니다. (이동평균기간, noise_factor는 상황에따라 수정해서 사용가능)
    - preprocess.py 의 insert_null_data 함수는 인위적으로 null데이터를 넣어서 테스트하기 위한 함수로 무시하셔도 됩니다. 필요시 사용하세요
    - save_raw_data_API_fn 태스크에서 몇분봉 데이터를 수집하는지를 minutes 라는 변수에 담아서 XCom에 저장해놓고 preprocess에서 이동평균 기간(period)을 정하는데 사용합니다 (p.155)
    
## Issue Tag
- Closed | Fixed: #65 
- See also: 노션 twd 참고
