### PR TITLE
[FIX] Rerange-and-fix-catboost-hyperparameter

### DIFF
--- a/dags/module/upbit_price_prediction/btc/classification.py
+++ b/dags/module/upbit_price_prediction/btc/classification.py
@@ -69,14 +69,14 @@ def train_catboost_model_fn(**context: dict) -> None:
         params = {
             "iterations": trial.suggest_int("iterations", 100, 1000),
             "learning_rate": trial.suggest_float("learning_rate", 1e-5, 1e-1, log=True),
-            "depth": trial.suggest_int("depth", 4, 10),
+            "depth": trial.suggest_int("depth", 6, 12),
             "l2_leaf_reg": trial.suggest_float("l2_leaf_reg", 1e-5, 10, log=True),
-            "bagging_temperature": trial.suggest_float("bagging_temperature", 0.0, 1.0),
-            "random_strength": trial.suggest_float(
-                "random_strength", 1e-5, 10, log=True
-            ),
-            "od_type": "Iter",
-            "od_wait": 100,
+            "bagging_temperature": trial.suggest_float("bagging_temperature", 0.0, 0.1), # bagging_temperature를 0에 가깝게 설정하여 데이터의 무작위성을 최소화한다.
+            "border_count": trial.suggest_int("border_count", 32, 255),  # 분할 수 설정
+            "feature_border_type": trial.suggest_categorical("feature_border_type", ["Median", "Uniform", "UniformAndQuantiles", "MaxLogSum", "MinEntropy", "GreedyLogSum"]),  # 경계 유형 설정
+            "random_strength": trial.suggest_float("random_strength", 1e-3, 10, log=True),  # 랜덤화 강도 조절
+            "od_type": "Test", # 검증 데이터에 대하여 성능 개선이 이루어지지 않을 경우 조기 종료
+            "od_wait": 10, # 10번의 학습에서 성능 개선이 이루어지지 않을 경우 조기 종료
         }
 
         model = CatBoostClassifier(**params, logging_level="Info")


### PR DESCRIPTION
## Overview
    - 시계열 데이터 적합 CatBoost 하이퍼파라미터 조정 및 학습 시간 감소
    
## Change Log
- 일부 하이퍼파라미터는 제거되었습니다.: `bagging_temperature`
- 일부 하이퍼파라미터가 추가되었습니다.: `border_count`, `feature_border_type`
- 일부 하이퍼파라미터가 변경되었습니다.: `od_type`, `od_wait`, `depth`
-`od_type`, `od_wait`과 `fit`의 `early_stopping`이 중복되는 부분 해결: 하이퍼파라미터 튜닝의 대상이 아닌, `early_stopping`만 사용하는 방식으로 변경함
- imbalanced data 여부를 확인하여 f1_score에 적절한 `average` 방식을 선택하도록 변경함
    
## To Reviewer
- [Archive: CatBoost 하이퍼파라미터](https://dohk325.notion.site/CatBoost-7447c41bafe9460b973cb53a8f530c37?pvs=4)
- [TWD: CatBoost 하이퍼파라미터 조정, 학습 속도 및 모델 성능 비교](https://dohk325.notion.site/CatBoost-6ec92e2c6f6044a8b3dc19193d4f6f86?pvs=4)
