### PR TITLE
[FEAT] redis 캐시서버 및 에러핸들러 구현 #73

### DIFF
--- a/backend-start.sh
+++ b/backend-start.sh
@@ -16,12 +16,23 @@ cd fastapi
 
 # Poetry 설치 및 종속성 설치
 pip install poetry
-poetry install
+poetry install --no-root
 
+# Redis 컨테이너가 이미 실행 중인지 확인하고, 실행 중이지 않으면 실행
+if [ ! "$(docker ps -q -f name=redis)" ]; then
+    if [ "$(docker ps -aq -f status=exited -f name=redis)" ]; then
+        # Cleanup
+        docker rm redis
+    fi
+    # Run Redis container
+    docker run --name redis -p 6379:6379 -d redis:7.2
+fi
+
+export ENV=local
 export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
 export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
 export MLFLOW_S3_ENDPOINT_URL=${MLFLOW_S3_ENDPOINT_URL}:${MLFLOW_S3_ENDPOINT_MAIN_PORT}
 export MLFLOW_TRACKING_URI=${MLFLOW_TRACKING_URI_LOCAL}:${MLFLOW_TRACKING_PORT}
 
 # FastAPI 서버 시작
-uvicorn app.main:app --reload
+poetry run uvicorn app.main:app --reload

--- a/dags/module/upbit_price_prediction/btc/create_table.py
+++ b/dags/module/upbit_price_prediction/btc/create_table.py
@@ -9,7 +9,6 @@ from sqlalchemy import (
     Float,
     Sequence,
     TIMESTAMP,
-    Numeric,
 )
 from sqlalchemy.orm import declarative_base
 from airflow.exceptions import AirflowSkipException

--- a/dags/module/upbit_price_prediction/btc/preprocess.py
+++ b/dags/module/upbit_price_prediction/btc/preprocess.py
@@ -1241,7 +1241,7 @@ async def preprocess_data(context: dict) -> None:
                 await session.execute(
                     select(BtcPreprocessed).order_by(BtcPreprocessed.time)
                 )
-                session.commit()
+                await session.commit()
                 logger.info("Sorting btc_preprocessed table by time")
                 count_final = await session.scalar(
                     select(func.count()).select_from(BtcPreprocessed)

--- a/dags/module/upbit_price_prediction/btc/preprocess.py
+++ b/dags/module/upbit_price_prediction/btc/preprocess.py
@@ -874,20 +874,25 @@ async def update_rsi_state_and_data(
             logger.info(
                 f"Updated RSI > 75 state: range_start={range_start_75}, range_end={range_end_75}, max_rsi={max_rsi_75}, max_rsi_time={max_rsi_time_75}"
             )
-
-            # 구간을 벗어났으므로 rsi_over업데이트
-            update_query = f"""
-            UPDATE btc_preprocessed
-            SET rsi_over = CASE
-                            WHEN time <= '{max_rsi_time_75}' THEN 1
-                            WHEN time > '{max_rsi_time_75}' THEN 0
-                            END
-            WHERE time BETWEEN '{range_start_75}' AND '{range_end_75}'
-            AND rsi_14 >= 75
-            """
-            await conn.execute(text(update_query))
-            await conn.commit()
-            logger.info(f"Updated btc_preprocessed rsi_over based on max_rsi_time_75")
+            if (
+                range_start_75 != "1970-01-01 00:00:00"
+                and range_end_75 != "1970-01-01 00:00:00"
+            ):
+                # 구간을 벗어났으므로 rsi_over업데이트
+                update_query = f"""
+                UPDATE btc_preprocessed
+                SET rsi_over = CASE
+                                WHEN time <= '{max_rsi_time_75}' THEN 1
+                                WHEN time > '{max_rsi_time_75}' THEN 0
+                                END
+                WHERE time BETWEEN '{range_start_75}' AND '{range_end_75}'
+                AND rsi_14 >= 75
+                """
+                await conn.execute(text(update_query))
+                await conn.commit()
+                logger.info(
+                    f"Updated btc_preprocessed rsi_over based on max_rsi_time_75"
+                )
 
             # 상태 초기화
             range_start_75 = range_end_75 = max_rsi_time_75 = "1970-01-01 00:00:00"
@@ -914,20 +919,25 @@ async def update_rsi_state_and_data(
             logger.info(
                 f"Updated RSI < 25 state: range_start={range_start_25}, range_end={range_end_25}, min_rsi={min_rsi_25}, min_rsi_time={min_rsi_time_25}"
             )
-
-            # 구간을 벗어났으므로 rsi_over업데이트
-            update_query = f"""
-            UPDATE btc_preprocessed
-            SET rsi_over = CASE
-                            WHEN time <= '{min_rsi_time_25}' THEN 0
-                            WHEN time > '{min_rsi_time_25}' THEN 1
-                        END
-            WHERE time BETWEEN '{range_start_25}' AND '{range_end_25}'
-            AND rsi_14 <= 25
-            """
-            await conn.execute(text(update_query))
-            await conn.commit()
-            logger.info(f"Updated btc_preprocessed rsi_over based on min_rsi_time_25")
+            if (
+                range_start_25 != "1970-01-01 00:00:00"
+                and range_end_25 != "1970-01-01 00:00:00"
+            ):
+                # 구간을 벗어났으므로 rsi_over업데이트
+                update_query = f"""
+                UPDATE btc_preprocessed
+                SET rsi_over = CASE
+                                WHEN time <= '{min_rsi_time_25}' THEN 0
+                                WHEN time > '{min_rsi_time_25}' THEN 1
+                            END
+                WHERE time BETWEEN '{range_start_25}' AND '{range_end_25}'
+                AND rsi_14 <= 25
+                """
+                await conn.execute(text(update_query))
+                await conn.commit()
+                logger.info(
+                    f"Updated btc_preprocessed rsi_over based on min_rsi_time_25"
+                )
 
             # 상태 초기화
             range_start_25 = range_end_25 = min_rsi_time_25 = "1970-01-01 00:00:00"

--- a/fastapi/app/core/auth.py
+++ b/fastapi/app/core/auth.py
@@ -1,0 +1,10 @@
+from typing import Optional
+
+from fastapi import Header
+
+from app.core.errors import error
+
+
+async def validate_api_key(api_key: Optional[str] = Header(None, alias="x-api-key")):
+    if api_key is None or api_key != "{API key}":
+        raise error.InvalidAPIKey()

--- a/fastapi/app/core/db/session.py
+++ b/fastapi/app/core/db/session.py
@@ -1,5 +1,3 @@
-from asyncio import current_task
-
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
@@ -8,8 +6,13 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 from sqlalchemy.orm import DeclarativeBase
+from starlette_context import context
 
 from app.core.config import config, is_local
+
+
+def get_session_id():
+    return context.get("session_id")
 
 
 class Base(DeclarativeBase): ...
@@ -23,7 +26,9 @@ async_session_factory = async_sessionmaker(
     engine, class_=AsyncSession, expire_on_commit=False
 )
 
-AsyncScopedSession = async_scoped_session(async_session_factory, scopefunc=current_task)
+AsyncScopedSession = async_scoped_session(
+    async_session_factory, scopefunc=get_session_id
+)
 
 
 async def ping_db():

--- a/fastapi/app/core/errors/error.py
+++ b/fastapi/app/core/errors/error.py
@@ -1,0 +1,52 @@
+ERROR_400_BTC_RAW_DATA_NOT_FOUND = "40000"
+ERROR_400_BTC_PREPROCESSED_DATA_NOT_FOUND = "40001"
+ERROR_400_PREDICT_MODEL_NOT_FOUND = "40002"
+ERROR_400_OUT_OF_RANGE = "40003"
+ERROR_401_INVALID_API_KEY = "40100"
+
+
+class BaseAPIException(Exception):
+    def __init__(self, code: str, message: str):
+        self.code = code
+        self.message = message
+
+
+class BtcOhlcvNotFoundException(BaseAPIException):
+    def __init__(self):
+        super().__init__(
+            code=ERROR_400_BTC_RAW_DATA_NOT_FOUND, message="BtcOhlcv not found."
+        )
+
+
+class BtcPreprocessedNotFoundException(BaseAPIException):
+    def __init__(self):
+        super().__init__(
+            code=ERROR_400_BTC_PREPROCESSED_DATA_NOT_FOUND,
+            message="BtcPreprocessed not found.",
+        )
+
+
+class OutOfRangeException(BaseAPIException):
+    def __init__(self):
+        super().__init__(
+            code=ERROR_400_OUT_OF_RANGE,
+            message="Your request is out of the allowed range.",
+        )
+
+
+class PredictModelNotFoundException(BaseAPIException):
+    def __init__(self):
+        super().__init__(
+            code=ERROR_400_PREDICT_MODEL_NOT_FOUND, message="PredictModel not found."
+        )
+
+
+class BaseAuthException(Exception):
+    def __init__(self, code: str, message: str):
+        self.code = code
+        self.message = message
+
+
+class InvalidAPIKey(BaseAuthException):
+    def __init__(self):
+        super().__init__(code=ERROR_401_INVALID_API_KEY, message="Invalid API Key")

--- a/fastapi/app/core/errors/handler.py
+++ b/fastapi/app/core/errors/handler.py
@@ -1,0 +1,25 @@
+from fastapi import Request
+from fastapi.responses import ORJSONResponse
+from starlette import status
+
+from app.core.errors.error import BaseAPIException, BaseAuthException
+
+
+async def api_error_handler(_: Request, exc: BaseAPIException) -> ORJSONResponse:
+    return ORJSONResponse(
+        content={
+            "statusCode": exc.code,
+            "message": exc.message,
+        },
+        status_code=status.HTTP_400_BAD_REQUEST,
+    )
+
+
+async def api_auth_error_handler(_: Request, exc: BaseAuthException) -> ORJSONResponse:
+    return ORJSONResponse(
+        content={
+            "statusCode": exc.code,
+            "message": exc.message,
+        },
+        status_code=status.HTTP_401_UNAUTHORIZED,
+    )

--- a/fastapi/app/core/lifespan.py
+++ b/fastapi/app/core/lifespan.py
@@ -1,0 +1,16 @@
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+
+from app.core.redis import redis_cache
+from app.core.db.session import ping_db, close_db
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await ping_db()
+    await redis_cache.ping()
+
+    yield
+
+    await close_db()
+    await redis_cache.close()

--- a/fastapi/app/core/middlewares/sqlalchemy.py
+++ b/fastapi/app/core/middlewares/sqlalchemy.py
@@ -1,0 +1,12 @@
+from uuid import uuid4
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette_context import context
+
+
+class SQLAlchemyMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        context["session_id"] = uuid4().hex
+
+        return await call_next(request)

--- a/fastapi/app/core/redis.py
+++ b/fastapi/app/core/redis.py
@@ -1,0 +1,67 @@
+import pickle
+from functools import wraps
+from typing import Callable
+from redis.asyncio import Redis
+from app.core.errors import error
+
+from app.core.config import config
+from app.core.logger import logger
+
+
+class RedisCache:
+    def __init__(self):
+        self.redis = Redis(
+            host=config.REDIS_HOST,
+            port=config.REDIS_PORT,
+        )
+
+    async def ping(self) -> None:
+        await self.redis.ping()
+
+    async def close(self) -> None:
+        await self.redis.close()
+
+    async def set(self, key: str, value: object, ttl: int = None) -> None:
+        await self.redis.set(key, pickle.dumps(value), ex=ttl)
+
+    async def get(self, key: str) -> object:
+        value = await self.redis.get(key)
+        return pickle.loads(value)
+
+    async def exists(self, key: str) -> bool:
+        return await self.redis.exists(key)
+
+
+class RedisCacheDecorator:
+    def __init__(self, ttl: int = 60):
+        self.ttl = ttl
+
+    def key_builder(self, f, kwargs) -> str:
+        return f"{f.__name__}.{str(kwargs)}"
+
+    def __call__(self, func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            _key = self.key_builder(func, kwargs=kwargs)
+
+            try:
+                if await redis_cache.exists(_key):
+                    logger.debug("Cache hit")
+                    result = await redis_cache.get(_key)
+                else:
+                    logger.debug("Cache miss")
+                    result = await func(*args, **kwargs)
+                    if result:
+                        logger.debug("Setting cache")
+                        await redis_cache.set(_key, result, ttl=self.ttl)
+
+            except Exception as e:
+                logger.error(f"Error in cache decorator: {e}")
+                result = await func(*args, **kwargs)
+
+            return result
+
+        return wrapper
+
+
+redis_cache = RedisCache()

--- a/fastapi/app/main.py
+++ b/fastapi/app/main.py
@@ -1,10 +1,45 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from starlette_context.middleware import ContextMiddleware
+
+from app.core.config import config
+from app.core.lifespan import lifespan
+from app.core.middlewares.sqlalchemy import SQLAlchemyMiddleware
+from app.core.errors.error import BaseAPIException
+from app.core.errors.handler import api_error_handler, api_auth_error_handler
 from app.routers import router
 
-app = FastAPI()
+app = FastAPI(lifesapn=lifespan, **config.fastapi_kwargs)
+
 app.include_router(router)
+app.add_exception_handler(BaseAPIException, api_error_handler)
+app.add_exception_handler(BaseAPIException, api_auth_error_handler)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+app.add_middleware(SQLAlchemyMiddleware)
+app.add_middleware(ContextMiddleware)
 
 
 @app.get("/")
 def read_root():
     return {"message": "Hello World"}
+
+
+# from app.core.db.session import AsyncScopedSession
+# from app.core.logger import logger
+
+# @app.get("/session/test")
+# async def session_test():
+#     async with AsyncScopedSession() as session:
+#         logger.debug(session)
+#     async with AsyncScopedSession() as session:
+#         logger.debug(session)
+#     async with AsyncScopedSession() as session:
+#         logger.debug(session)
+#     async with AsyncScopedSession() as session:
+#         logger.debug(session)

--- a/fastapi/app/models/db/model.py
+++ b/fastapi/app/models/db/model.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from sqlalchemy import DateTime, Integer
+from sqlalchemy import DateTime, Integer, Float
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
 from app.core.db.session import Base
@@ -13,7 +13,7 @@ class BtcOhlcv(Base):
     high: Mapped[int] = mapped_column(Integer)
     low: Mapped[int] = mapped_column(Integer)
     close: Mapped[int] = mapped_column(Integer)
-    volume: Mapped[int] = mapped_column(Integer)
+    volume: Mapped[float] = mapped_column(Float)
 
 
 class BtcPreprocessed(Base):
@@ -24,4 +24,10 @@ class BtcPreprocessed(Base):
     high: Mapped[int] = mapped_column(Integer)
     low: Mapped[int] = mapped_column(Integer)
     close: Mapped[int] = mapped_column(Integer)
-    volume: Mapped[int] = mapped_column(Integer)
+    volume: Mapped[float] = mapped_column(Float)
+    label: Mapped[int] = mapped_column(Integer)
+    ma_7: Mapped[int] = mapped_column(Integer)
+    ma_14: Mapped[int] = mapped_column(Integer)
+    ma_30: Mapped[int] = mapped_column(Integer)
+    rsi_14: Mapped[float] = mapped_column(Float)
+    rsi_over: Mapped[float] = mapped_column(Float)

--- a/fastapi/app/models/schemas/common.py
+++ b/fastapi/app/models/schemas/common.py
@@ -12,6 +12,11 @@ class BaseResponse(BaseModel, Generic[T]):
     data: Optional[T] = None
 
 
+class ErrorResponse(BaseModel):
+    message: str
+    statusCode: str
+
+
 class HttpResponse(ORJSONResponse):
     def __init__(self, content: Optional[T] = None, **kwargs):
         super().__init__(

--- a/fastapi/app/models/schemas/data_test.py
+++ b/fastapi/app/models/schemas/data_test.py
@@ -10,7 +10,7 @@ class BtcOhlcvResp:
     high: int = Field(..., title="High")
     low: int = Field(..., title="Low")
     close: int = Field(..., title="Close")
-    volume: int = Field(..., title="Volume")
+    volume: float = Field(..., title="Volume")
 
 
 @dataclass
@@ -20,4 +20,9 @@ class BtcPreprocessedResp:
     high: int = Field(..., title="High")
     low: int = Field(..., title="Low")
     close: int = Field(..., title="Close")
-    volume: int = Field(..., title="Volume")
+    volume: float = Field(..., title="Volume")
+    ma_7: int = Field(..., title="MA_7")
+    ma_14: int = Field(..., title="MA_14")
+    ma_30: int = Field(..., title="MA_30")
+    rsi_14: float = Field(..., title="RSI")
+    rsi_over: float = Field(..., title="RSI_over")

--- a/fastapi/app/routers/data_test.py
+++ b/fastapi/app/routers/data_test.py
@@ -1,53 +1,115 @@
 from fastapi import APIRouter
+from app.core.logger import logger
 from app.core.db.session import AsyncScopedSession
+from app.core.redis import RedisCacheDecorator
+from app.core.errors import error
 from app.models.db.model import BtcOhlcv, BtcPreprocessed
-from sqlalchemy.future import select
-from app.models.schemas.common import BaseResponse, HttpResponse
+from sqlalchemy import select, func
+from app.models.schemas.common import BaseResponse, HttpResponse, ErrorResponse
 from app.models.schemas.data_test import BtcOhlcvResp, BtcPreprocessedResp
 from typing import List
 
 router = APIRouter()
 
 
-@router.get("/btc_ohlcv/", response_model=BaseResponse[List[BtcOhlcvResp]])
+@router.get(
+    "/btc_ohlcv/",
+    response_model=BaseResponse[List[BtcOhlcvResp]],
+    responses={400: {"model": ErrorResponse}},
+)
+@RedisCacheDecorator()
 async def read_btc_ohlcv(skip: int = 0, limit: int = 10) -> HttpResponse:
     async with AsyncScopedSession() as session:
-        stmt = select(BtcOhlcv).offset(skip).limit(limit)
-        result = (await session.execute(stmt)).scalars().all()
+        try:
+            # 전체 데이터 개수 조회
+            total_count: int = await session.scalar(select(func.count(BtcOhlcv.time)))
 
-        response_data = [
-            BtcOhlcvResp(
-                time=record.time,
-                open=record.open,
-                high=record.high,
-                low=record.low,
-                close=record.close,
-                volume=record.volume,
-            )
-            for record in result
-        ]
+            if skip >= total_count:
+                raise error.OutOfRangeException()
 
-        return HttpResponse(content=response_data)
+            if skip + limit > total_count:
+                limit = total_count - skip
+
+            stmt = select(BtcOhlcv).offset(skip).limit(limit)
+            result: List[BtcOhlcv] = (await session.execute(stmt)).scalars().all()
+
+            response_data: List[BtcOhlcvResp] = [
+                BtcOhlcvResp(
+                    time=record.time,
+                    open=record.open,
+                    high=record.high,
+                    low=record.low,
+                    close=record.close,
+                    volume=record.volume,
+                )
+                for record in result
+            ]
+
+            return HttpResponse(content=response_data)
+
+        except error.OutOfRangeException as e:
+            logger.error(e)
+            raise
+
+        except Exception as e:
+            logger.error(e)
+            raise error.BtcOhlcvNotFoundException()
 
 
 @router.get(
-    "/btc_preprocessed/", response_model=BaseResponse[List[BtcPreprocessedResp]]
+    "/btc_preprocessed/",
+    response_model=BaseResponse[List[BtcPreprocessedResp]],
+    responses={400: {"model": ErrorResponse}},
 )
-async def read_btc_ohlcv(skip: int = 0, limit: int = 10) -> HttpResponse:
+@RedisCacheDecorator()
+async def read_btc_preprocessed(skip: int = 0, limit: int = 10) -> HttpResponse:
+    """
+    btc_preprocessed 데이터 개수: 105120
+    """
     async with AsyncScopedSession() as session:
-        stmt = select(BtcPreprocessed).offset(skip).limit(limit)
-        result = (await session.execute(stmt)).scalars().all()
-
-        response_data = [
-            BtcOhlcvResp(
-                time=record.time,
-                open=record.open,
-                high=record.high,
-                low=record.low,
-                close=record.close,
-                volume=record.volume,
+        try:
+            total_count: int = await session.scalar(
+                select(func.count(BtcPreprocessed.time))
             )
-            for record in result
-        ]
 
-        return HttpResponse(content=response_data)
+            if skip < 0 or limit <= 0 or skip >= total_count:
+                raise error.OutOfRangeException()
+
+            if skip + limit > total_count:
+                limit = max(total_count - skip, 0)
+
+            stmt = (
+                select(BtcPreprocessed)
+                .order_by(BtcPreprocessed.time)
+                .offset(skip)
+                .limit(limit)
+            )
+            result: List[(BtcPreprocessed)] = (
+                (await session.execute(stmt)).scalars().all()
+            )
+
+            if not result:
+                raise error.BtcPreprocessedNotFoundException()
+
+            response_data: List[BtcPreprocessedResp] = [
+                BtcPreprocessedResp(
+                    time=record.time,
+                    open=record.open,
+                    high=record.high,
+                    low=record.low,
+                    close=record.close,
+                    volume=record.volume,
+                    ma_7=record.ma_7,
+                    ma_14=record.ma_14,
+                    ma_30=record.ma_30,
+                    rsi_14=record.rsi_14,
+                    rsi_over=record.rsi_over,
+                )
+                for record in result
+            ]
+
+            return HttpResponse(content=response_data)
+
+        except Exception as e:
+            logger.error(e)
+            raise

--- a/poetry.lock
+++ b/poetry.lock
@@ -2193,6 +2193,24 @@ files = [
 six = "*"
 
 [[package]]
+name = "redis"
+version = "5.0.6"
+description = "Python client for Redis database and key-value store"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "redis-5.0.6-py3-none-any.whl", hash = "sha256:c0d6d990850c627bbf7be01c5c4cbaadf67b48593e913bb71c9819c30df37eee"},
+    {file = "redis-5.0.6.tar.gz", hash = "sha256:38473cd7c6389ad3e44a91f4c3eaf6bcb8a9f746007f29bf4fb20824ff0b2197"},
+]
+
+[package.dependencies]
+async-timeout = {version = ">=4.0.3", markers = "python_full_version < \"3.11.3\""}
+
+[package.extras]
+hiredis = ["hiredis (>=1.0.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
+
+[[package]]
 name = "requests"
 version = "2.32.3"
 description = "Python HTTP for Humans."
@@ -2423,6 +2441,20 @@ anyio = ">=3.4.0,<5"
 
 [package.extras]
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.7)", "pyyaml"]
+
+[[package]]
+name = "starlette-context"
+version = "0.3.6"
+description = "Middleware for Starlette that allows you to store and access the context data of a request. Can be used with logging so logs automatically use request headers such as x-request-id or x-correlation-id."
+optional = false
+python-versions = ">=3.8,<4.0"
+files = [
+    {file = "starlette_context-0.3.6-py3-none-any.whl", hash = "sha256:b14ce373fbb6895a2182a7104b9f63ba20c8db83444005fb9a844dd77ad9895c"},
+    {file = "starlette_context-0.3.6.tar.gz", hash = "sha256:d361a36ba2d4acca3ab680f917b25e281533d725374752d47607a859041958cb"},
+]
+
+[package.dependencies]
+starlette = "*"
 
 [[package]]
 name = "tabulate"
@@ -2779,4 +2811,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "d68f1af8e96b4bf895b22c144378ff10bf7b449277c7be3eaa95749f1ca2042a"
+content-hash = "8a972a494e7f6d1f8653c116d50ea5f9334fac8562005836c59c9366b410d85f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ orjson = "^3.10.3"
 minio = "^7.2.7"
 catboost = "^1.2.5"
 python-dotenv = "^1.0.1"
+redis = "^5.0.6"
+starlette-context = "^0.3.6"
 
 
 [build-system]


### PR DESCRIPTION
## Overview
    - redis 서버 및 에러핸들러 구현하고 이전 베이스라인 코드에 적용
    - 중간에 확인하다가 airflow 코드에서 문제점 발견 후 개선
        
## Change Log
    - redis, errorhandler, middleware 추가
    - preprocess의 rsi_over 관련 오류 수정
    - 정렬이 안된 데이터로 학습되던 문제 수정
    - conn.execute() -> session.execute() 로 수정
    - backend-start.sh 파일 poetry run, redis 도커파일 실행, ENV 설정하는 부분 추가
    
## To Reviewer
    - 정렬이 된 데이터로 학습하도록 설정해서 기존 모델들과 결과가 다를겁니다 확인해주세요
    - rsi_over 잘 들어오는지 중간에 확인한번 부탁드립니다
    - 모델들이 많이 쌓이면서 용량을 꽤 차지하는데 시간이 지난 모델은 제거하는 코드가 필요할 것 같습니다
    - 노션에 좀 더 자세하게 적어놨습니다
    
## Issue Tag
- Closed | Fixed: #73 
- See also: https://www.notion.so/dohk325/fastapi-redis-5273452b66b04f129e54e9d084c128c3?pvs=4
