### PR TITLE
[FIX] Remove time column when training

### DIFF
--- a/dags/module/upbit_price_prediction/btc/classification.py
+++ b/dags/module/upbit_price_prediction/btc/classification.py
@@ -63,7 +63,7 @@ def train_catboost_model_fn(**context: dict) -> None:
 
     df = asyncio.run(load_data(engine))
 
-    X = df.drop(columns=["label"])
+    X = df.drop(columns=["label", "time"])
     y = df["label"]
 
     # 시계열 데이터를 시간 순서에 따라 분할


### PR DESCRIPTION
## Overview
    - 학습 성능 개선
    
## Change Log
    - 학습 시 time 열 제거
    
## To Reviewer
현재 저희는 time열을 학습시에 사용하고 있는데, 결과를 비교해보니 time열을 빼는 것이 더 적합해보여서 time열을 제거했습니다.
또한 저희는 time열을 오로지 정렬을 목적으로만 사용하기 때문에, 이미 정렬이 된 상태의 데이터로 학습을 수행한다면 학습 시에는 제거하는 것이 적합해보입니다.

time열 제거 전 결과
![image](https://github.com/MLOps-CoinAssistant/MLOps-project/assets/25498099/8d8c8ce0-376b-4802-bdb5-30f2ee986a21)

time열 제거 후 결과
![image](https://github.com/MLOps-CoinAssistant/MLOps-project/assets/25498099/dd8d26dd-c144-48f2-8dfd-d1e18435e68e)

결과를 비교해보면 라벨 1에 대한 recall과 F1 score값이 상슨한 것을 확인할 수 있습니다.
