### PR TITLE
[FEAT] xai endpoint

### DIFF
--- a/dags/module/upbit_price_prediction/btc/classification.py
+++ b/dags/module/upbit_price_prediction/btc/classification.py
@@ -18,6 +18,7 @@ import mlflow
 import uvloop
 import time
 import numpy as np
+from sklearn.inspection import permutation_importance
 
 
 # uvloop를 기본 이벤트 루프로 설정
@@ -150,6 +151,20 @@ def train_catboost_model_fn(**context: dict) -> None:
     logger.info(f"Validation accuracy: {accuracy}")
     logger.info(f"F1 Score: {f1}")
     logger.info(f"Classification Report:\n{report}")
+
+    # Permutation Importance 계산
+    perm_importance = permutation_importance(
+        model, X_valid, y_valid, n_repeats=10, random_state=42
+    )
+    perm_importance_df = pd.DataFrame(
+        {
+            "feature": X_valid.columns,
+            "importance_mean": perm_importance.importances_mean,
+            "importance_std": perm_importance.importances_std,
+        }
+    ).sort_values(by="importance_mean", ascending=False)
+
+    logger.info(f"Permutation Importance:\n{perm_importance_df}")
 
     metrics = {
         "accuracy": accuracy,

--- a/fastapi/app/core/errors/error.py
+++ b/fastapi/app/core/errors/error.py
@@ -1,6 +1,7 @@
 ERROR_400_BTC_RAW_DATA_NOT_FOUND = "40000"
 ERROR_400_BTC_PREPROCESSED_DATA_NOT_FOUND = "40001"
 ERROR_400_PREDICT_MODEL_NOT_FOUND = "40002"
+ERROR_400_BTC_FEATURE_IMPORTACES_NOT_FOUND = "40003"
 ERROR_400_OUT_OF_RANGE = "40003"
 ERROR_401_INVALID_API_KEY = "40100"
 
@@ -23,6 +24,14 @@ class BtcPreprocessedNotFoundException(BaseAPIException):
         super().__init__(
             code=ERROR_400_BTC_PREPROCESSED_DATA_NOT_FOUND,
             message="BtcPreprocessed not found.",
+        )
+
+
+class BtcFeatureImportancesNotFoundException(BaseAPIException):
+    def __init__(self):
+        super().__init__(
+            code=ERROR_400_BTC_FEATURE_IMPORTACES_NOT_FOUND,
+            message="BtcFeatureImportances is not found.",
         )
 
 

--- a/fastapi/app/models/db/model.py
+++ b/fastapi/app/models/db/model.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from sqlalchemy import DateTime, Integer, Float
+from sqlalchemy import DateTime, Integer, Float, String
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
 from app.core.db.session import Base
@@ -29,5 +29,22 @@ class BtcPreprocessed(Base):
     ma_7: Mapped[int] = mapped_column(Integer)
     ma_14: Mapped[int] = mapped_column(Integer)
     ma_30: Mapped[int] = mapped_column(Integer)
+    rsi_14: Mapped[float] = mapped_column(Float)
+    rsi_over: Mapped[float] = mapped_column(Float)
+
+
+class BTCFeatureImportances(Base):
+    __tablename__ = "btc_importance"
+    run_id: Mapped[str] = mapped_column(String, primary_key=True)
+    experiment_name: Mapped[str] = mapped_column(String)
+    time: Mapped[datetime] = mapped_column(DateTime)
+    open: Mapped[float] = mapped_column(Float)
+    high: Mapped[float] = mapped_column(Float)
+    low: Mapped[float] = mapped_column(Float)
+    close: Mapped[float] = mapped_column(Float)
+    volume: Mapped[float] = mapped_column(Float)
+    ma_7: Mapped[float] = mapped_column(Float)
+    ma_14: Mapped[float] = mapped_column(Float)
+    ma_30: Mapped[float] = mapped_column(Float)
     rsi_14: Mapped[float] = mapped_column(Float)
     rsi_over: Mapped[float] = mapped_column(Float)

--- a/fastapi/app/models/schemas/xai.py
+++ b/fastapi/app/models/schemas/xai.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from pydantic import Field
+from pydantic.dataclasses import dataclass
+
+
+@dataclass
+class BTCFeatureImportancesResp:
+    run_id: str = Field(..., title="run id")
+    experiment_name: str = Field(..., title="experiment_name")
+    time: datetime = Field(..., title="Time")
+    open: float = Field(..., title="Open")
+    high: float = Field(..., title="High")
+    low: float = Field(..., title="Low")
+    close: float = Field(..., title="Close")
+    volume: float = Field(..., title="Volume")
+    ma_7: float = Field(..., title="MA_7")
+    ma_14: float = Field(..., title="MA_14")
+    ma_30: float = Field(..., title="MA_30")
+    rsi_14: float = Field(..., title="RSI")
+    rsi_over: float = Field(..., title="RSI_over")

--- a/fastapi/app/routers/__init__.py
+++ b/fastapi/app/routers/__init__.py
@@ -1,9 +1,10 @@
 from fastapi import APIRouter, Depends
 
-from app.routers import data_test, predict
+from app.routers import data_test, predict, xai
 
 
 router = APIRouter(prefix="/v1")
 
 router.include_router(data_test.router, prefix="/data", tags=["data"])
 router.include_router(predict.router, prefix="/predict", tags=["predict"])
+router.include_router(xai.router, prefix="/xai", tags=["xai"])

--- a/fastapi/app/routers/xai.py
+++ b/fastapi/app/routers/xai.py
@@ -1,0 +1,71 @@
+from fastapi import APIRouter, HTTPException
+from app.core.logger import logger
+from app.core.db.session import AsyncScopedSession
+from app.core.redis import RedisCacheDecorator
+from app.core.errors import error
+from app.models.db.model import BTCFeatureImportances
+from sqlalchemy import select, func
+from app.models.schemas.common import BaseResponse, HttpResponse, ErrorResponse
+from app.models.schemas.xai import BTCFeatureImportancesResp
+from typing import List
+
+router = APIRouter()
+
+
+# XAI 결과 호출 엔드포인트
+@router.get(
+    "/importances",
+    response_model=BaseResponse[List[BTCFeatureImportancesResp]],
+    responses={400: {"model": ErrorResponse}},
+)
+@RedisCacheDecorator()
+async def get_importances(skip: int = 0, limit: int = 10) -> HttpResponse:
+    async with AsyncScopedSession() as session:
+        try:
+            total_count: int = await session.scalar(
+                select(func.count(BTCFeatureImportances.run_id))
+            )
+            if skip < 0 or limit <= 0 or skip >= total_count:
+                raise error.OutOfRangeException()
+
+            if skip + limit > total_count:
+                limit = max(total_count - skip, 0)
+
+            stmt = select(BTCFeatureImportances).offset(skip).limit(limit)
+            result: List[(BTCFeatureImportances)] = (
+                (await session.execute(stmt)).scalars().all()
+            )
+
+            if not result:
+                raise error.BtcFeatureImportancesNotFoundException
+
+            response_data: List[BTCFeatureImportancesResp] = [
+                BTCFeatureImportancesResp(
+                    run_id=record.run_id,
+                    experiment_name=record.experiment_name,
+                    time=record.time,
+                    open=record.open,
+                    high=record.high,
+                    low=record.low,
+                    close=record.close,
+                    volume=record.volume,
+                    ma_7=record.ma_7,
+                    ma_14=record.ma_14,
+                    ma_30=record.ma_30,
+                    rsi_14=record.rsi_14,
+                    rsi_over=record.rsi_over,
+                )
+                for record in result
+            ]
+
+            return HttpResponse(content=response_data)
+
+        except error.OutOfRangeException as e:
+            logger.error(e)
+            raise HTTPException(status_code=400, detail="Out of range error")
+        except error.BtcFeatureImportancesNotFoundException as e:
+            logger.error(e)
+            raise HTTPException(status_code=404, detail="Importances not found")
+        except Exception as e:
+            logger.error(e)
+            raise HTTPException(status_code=500, detail="Internal server error")


### PR DESCRIPTION
## Overview
이번 PR은 CatBoost 모델의 학습 과정에 XAI(설명 가능한 인공지능) 기능을 추가하고, 이를 별도의 작업으로 정의하여 이후 작업들과 병렬로 실행되도록 수정하였습니다. 또한, XAI 결과를 데이터베이스에 저장하는 기능과 XAI 결과를 조회할 수 있는 엔드포인트를 생성하였습니다.
    
## Change Log
    1. Permutation Importance 기능 추가
    2. XAI 기능을 train_catboost_model_fn 함수 내에서 별도의 작업으로 정의하고, 이후 작업들과 병렬로 실행되도록 수정
    3. XAI 결과를 데이터베이스에 저장하도록 수정
    4. XAI 결과를 조회할 수 있는 엔드포인트 생성
    
## To Reviewer
- XAI 기능이 추가됨에 따라 전체 파이프라인 수행 시간이 다소 증가할 수 있습니다. 다만, 해당 태스크를 병렬로 실행하도록 하였기 때문에 큰 영향은 없을 것으로 보입니다.
- 병렬 처리로 인해 성능에 큰 영향은 없을 것으로 예상되나, 필요한 경우 성능 최적화를 고려할 수 있습니다. 
- 데이터베이스 저장 기능 및 새로 생성된 엔드포인트가 올바르게 동작하는지 확인 부탁드립니다.
    
## Issue Tag
- Closed : #75
