### PR TITLE
[FEAT] #81: Managed MLflow experiment history for non-production model…

### DIFF
--- a/info/__init__.py
+++ b/info/__init__.py
@@ -1,3 +1,3 @@
-from . import connections, api, coins
+from . import connections, api, coins, minio_config
 
-all = ["Connections", "api", "coins"]
+all = ["Connections", "api", "coins", "MinioConfig"]

--- a/info/minio_config.py
+++ b/info/minio_config.py
@@ -1,0 +1,8 @@
+import os
+from enum import Enum
+
+
+class MinioConfig(Enum):
+    MINIO_SERVER_URL: str = os.getenv("MLFLOW_S3_ENDPOINT_URL")
+    MINIO_ACCESS_KEY: str = os.getenv("AWS_ACCESS_KEY_ID")
+    MINIO_SECRET_KEY: str = os.getenv("AWS_SECRET_ACCESS_KEY")


### PR DESCRIPTION
## Overview
Production 버전이 아닌 모델에 대한 실험 이력은 유지하되, 아티팩트는 제거하여 아티팩트 스토어의 공간을 관리합니다.
    
## Change Log
    1. trainsition_model_task 단계에서 Production이 아닌 모델 제거
    2. 환경변수를 이용하여 MinIO 연결 정보 가져오는 기능 추가
    3. Airflow 대시보드에서 실험 결과 확인
    4. MLflow 대시보드에서 실험 결과 확인
    5. MinIO 대시보드에서 실험 결과 확인
    
## To Reviewer
XAI 기능을 통해 해당 실험에 대한 XAI 결과를 기록하기 위해서는 학습된 모델이 필요하기 때문에, trainsition_model_task 단계에서 Production이 아닌 모델은 제거하도록 하였습니다. 
각 대시보드(Airflow, MLflow, MinIO)에서 실험 결과가 올바르게 확인되는지 검토 부탁드립니다.

**Airflow Logs**
![image](https://github.com/MLOps-CoinAssistant/MLOps-project/assets/25498099/69f5847c-eb4c-4636-8ccd-8e3965824b1b)
실험 ID: be17debe96c4433eb34496524b5b6b07

**MLflow dashboard**
![image](https://github.com/MLOps-CoinAssistant/MLOps-project/assets/25498099/a1020188-1966-4173-9815-e6ec0059385e)
![image](https://github.com/MLOps-CoinAssistant/MLOps-project/assets/25498099/9a9eeee1-71a4-4702-94b8-465cdf4c3770)
아티팩트가 보이지 않는 것을 확인할 수 있습니다.

**MinIO dashboard**
![image](https://github.com/MLOps-CoinAssistant/MLOps-project/assets/25498099/37152330-bfcf-4307-9892-7f643389b0b1)
해당 실험 ID로 아티팩트가 검색되지 않음을 확인할 수 있습니다.
    
## Issue Tag
- Closed: #81 
