### PR TITLE
[fix] #95: Add specific version of pip into Dockerfile-mlflow

### DIFF
--- a/Dockerfile-mlflow
+++ b/Dockerfile-mlflow
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install -U pip && \
+RUN pip install pip==24.0 && \
     pip install mlflow==1.27.0 psycopg2-binary boto3 sqlalchemy==1.4.52
 
 RUN cd /tmp && \


### PR DESCRIPTION
 #95

## Overview
- 작업 환경을 새로 구성하던 중, pip 버전 이슈 발생
    
## Change Log
- pip 버전을 구체적으로 명시하도록 수정함
    
## To Reviewer
- pip 버전이 24.0 버전으로 고정되었습니다.
- 환경 구성을 하시어 테스트하시는 것이 베스트이긴 합니다. 제 Compute Engine 환경에서는 이 문제가 발생하여 다른 분들께도 동일한 문제가 발생할 것으로 예상되어 develop 브랜치로 push하고자 합니다.

## Acceptance Criteria
- 서버 환경구성이 정상적으로 수행됨
    
## Issue Tag
- Fixed: #95
- See also: [GCP 환경 구성(개인 개발 환경)](https://dohk325.notion.site/GCP-2f426f784cbb460c937053656c7e0f45?pvs=4)
